### PR TITLE
Bootstrap/apollo next OpenAI

### DIFF
--- a/app/api/graphql/route.ts
+++ b/app/api/graphql/route.ts
@@ -1,0 +1,14 @@
+import { typeDefs } from '../../../graphql/schema';
+import { resolvers } from '../../../graphql/resolvers';
+import { ApolloServer } from '@apollo/server';
+import { startServerAndCreateNextHandler } from '@as-integrations/next';
+
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+});
+
+const handler = startServerAndCreateNextHandler(server);
+
+export const GET = handler;
+export const POST = handler;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>eShaman App</h1>
+      <p>This is th starting point for your Apollo + Next.js app.</p>
+    </div>
+  );
+}

--- a/graphql/graphql/resolvers.ts
+++ b/graphql/graphql/resolvers.ts
@@ -1,0 +1,5 @@
+export const resolvers = {
+Query: {
+    health: () => 'OK',
+  },
+};

--- a/graphql/schema.ts
+++ b/graphql/schema.ts
@@ -1,0 +1,7 @@
+import { gql } from '@apollo/server';
+
+export const typeDefs = gql`
+  type Query {
+    health: String
+  }
+`;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "next": "14.2.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "@apollo/server": "^4.8.0",
+    "@as-integrations/next": "^1.2.0",
+    "graphql": "^16.8.1"
   },
   "devDependencies": {
     "typescript": "^5.5.0",


### PR DESCRIPTION
This pull request sets up the foundational GraphQL API integration for the Next.js app using Apollo Server. It introduces a basic schema and resolver, configures the API route for GraphQL queries, and adds a simple home page. The most important changes are grouped below:

GraphQL API Setup:

* Added GraphQL schema definition with a `health` query in `graphql/schema.ts`.
* Implemented corresponding resolver for the `health` query in `graphql/resolvers.ts`.
* Created the GraphQL API route in `app/api/graphql/route.ts`, initializing Apollo Server with the schema and resolvers, and exporting handlers for GET and POST requests.

App Initialization:

* Added a basic landing page in `app/page.tsx` as a starting point for the Apollo + Next.js app.

Dependency Management:

* Installed required dependencies for Apollo Server, GraphQL, and Next.js integration in `package.json`.